### PR TITLE
Update .bash_profile if exists during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Lunchbox will install the following things:
 installation
 ------------
 
+First - run either of the following commands
+
 ```
 bash < <(wget -O - https://raw.github.com/bigspring/lunchbox/master/lunchbox-installer)
 ```
@@ -39,8 +41,10 @@ or
 bash < <(curl -s https://raw.github.com/bigspring/lunchbox/master/lunchbox-installer)
 ```
 
+Second - run the following (change to `.profile` if `.bash_profile` does not exist)
+
 ```
-source ~/.profile
+source ~/.bash_profile
 ```
 
 Note: Lunchbox is simply a bash script, so to use it you just need to place it in your $PATH and change it's mode to executable.
@@ -56,6 +60,7 @@ usage
 changelog
 ------
 
+* 12/08/13 - v1.0.5 - account for .bash_profile during installation
 * 12/08/13 - v1.0.4 - updated path in readme and installation file
 * 12/08/13 - v1.0.3 - hassle free installation
 * 12/08/13 - v1.0.2 - updated monolith package to use master (v1.0)

--- a/lunchbox
+++ b/lunchbox
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# lunchbox v1.0.3
+# lunchbox v1.0.5
 # built by @bigspringweb
 
 # downloads latest stable build of WordPress

--- a/lunchbox-installer
+++ b/lunchbox-installer
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 
+# attempt to add $HOME/bin PATH to users .bash_profile (or .profile) if it is not already present
 if [ ! -d "$HOME/bin" ] ; then
     mkdir $HOME/bin
 
-    if [ -f $HOME/.profile ]; then
-        . $HOME/.profile
+    if [ -f $HOME/.bash_profile ]; then
+        . $HOME/.bash_profile
 
         if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
-            echo -e '\nPATH="$HOME/bin:$PATH"' >> $HOME/.profile
+            echo -e '\nPATH="$PATH:$HOME/bin"' >> $HOME/.bash_profile
+        fi
+    else
+        if [ -f $HOME/.profile ]; then
+            . $HOME/.profile
+        else
+            touch $HOME/.profile
+        fi
+
+        if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+            echo -e '\nPATH="$PATH:$home/bin"' >> $HOME/.profile
         fi
     fi
 fi


### PR DESCRIPTION
The install script previously was attempting to update .profile. If the user is using a .bash_profile file .profile is not loaded.

lunchbox-install will now check for the existence of .bash_profile and modify if required - falling back on .profile.
